### PR TITLE
Return an empty Optional if Installation Manager cannot be loaded

### DIFF
--- a/src/main/java/org/wildfly/installationmanager/InstallationManagerFinder.java
+++ b/src/main/java/org/wildfly/installationmanager/InstallationManagerFinder.java
@@ -16,6 +16,8 @@ public class InstallationManagerFinder {
             for (InstallationManagerFactory imf : sl) {
                return Optional.of(imf);
             }
+        } catch (Exception e) {
+            // Cannot load InstallationManagerFactory service, ignored to return an empty Optional
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(currentTccl);
         }


### PR DESCRIPTION
In case of an error loading an Installation Manager implementation, return an empty Optional