### PR TITLE
Add option to generate PS1 script via the SPI

### DIFF
--- a/src/main/java/org/wildfly/installationmanager/spi/InstallationManager.java
+++ b/src/main/java/org/wildfly/installationmanager/spi/InstallationManager.java
@@ -135,6 +135,7 @@ public interface InstallationManager {
      * @return a CLI command.
      * @throws OperationNotAvailableException - if the installation manager CLI support is not installed
      */
+    @Deprecated
     String generateApplyUpdateCommand(Path scriptHome, Path candidatePath) throws OperationNotAvailableException;
 
     /**
@@ -146,5 +147,30 @@ public interface InstallationManager {
      * @return a CLI command.
      * @throws OperationNotAvailableException - if the installation manager CLI support is not installed
      */
+    @Deprecated
     String generateApplyRevertCommand(Path scriptHome, Path candidatePath) throws OperationNotAvailableException;
+
+    /**
+     * Generate an apply update CLI command.
+     * The generated command can be run in separate process to apply changes.
+     *
+     * @param candidatePath - Specify the directory path of the candidate installation to apply.
+     * @param scriptHome - Specify the directory path containing the script used to execute the apply command.
+     * @param shell - Specify what shell should the script be runnable in
+     * @return a CLI command.
+     * @throws OperationNotAvailableException - if the installation manager CLI support is not installed
+     */
+    String generateApplyUpdateCommand(Path scriptHome, Path candidatePath, OsShell shell) throws OperationNotAvailableException;
+
+    /**
+     * Generate an apply rollback CLI command.
+     * The generated command can be run in separate process to apply changes.
+     *
+     * @param candidatePath - Specify the directory path of the candidate installation to apply.
+     * @param scriptHome - Specify the directory path containing the script used to execute the apply command.
+     * @param shell - Specify what shell should the script be runnable in
+     * @return a CLI command.
+     * @throws OperationNotAvailableException - if the installation manager CLI support is not installed
+     */
+    String generateApplyRevertCommand(Path scriptHome, Path candidatePath, OsShell shell) throws OperationNotAvailableException;
 }

--- a/src/main/java/org/wildfly/installationmanager/spi/OsShell.java
+++ b/src/main/java/org/wildfly/installationmanager/spi/OsShell.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.installationmanager.spi;
+
+/**
+ * Represents supported shells for the installation manager scripts.
+ */
+public enum OsShell {
+    Linux, WindowsBash, WindowsPowerShell
+}


### PR DESCRIPTION
Support generating PowerShell script as well as bat for Windows. The caller is responsible for choosing correct script type for their OS