### PR TITLE
Add API methods that allow to override manifest versions for upgrade ops

### DIFF
--- a/src/main/java/org/wildfly/installationmanager/AvailableManifestVersions.java
+++ b/src/main/java/org/wildfly/installationmanager/AvailableManifestVersions.java
@@ -1,0 +1,37 @@
+package org.wildfly.installationmanager;
+
+import java.util.List;
+
+/**
+ * Provides list of available manifest versions for given channel.
+ */
+public class AvailableManifestVersions {
+
+    private final String channelName;
+    private final String location;
+    private final ManifestVersionPair currentVersion;
+    private final List<ManifestVersionPair> availableVersions;
+
+    public AvailableManifestVersions(String channelName, String location, ManifestVersionPair currentVersion, List<ManifestVersionPair> availableVersions) {
+        this.channelName = channelName;
+        this.location = location;
+        this.currentVersion = currentVersion;
+        this.availableVersions = availableVersions;
+    }
+
+    public String getChannelName() {
+        return channelName;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public ManifestVersionPair getCurrentVersion() {
+        return currentVersion;
+    }
+
+    public List<ManifestVersionPair> getAvailableVersions() {
+        return availableVersions;
+    }
+}

--- a/src/main/java/org/wildfly/installationmanager/InstallationUpdates.java
+++ b/src/main/java/org/wildfly/installationmanager/InstallationUpdates.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2023 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.installationmanager;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents possible incoming updates applicable to the installation.
+ */
+public class InstallationUpdates {
+
+    private final List<ArtifactChange> artifactUpdates;
+    private final List<ManifestVersionChange> manifestUpdates;
+
+    /**
+     * Constructor
+     * @param artifactUpdates list of artifact changes or empty list if no changes found
+     * @param manifestUpdates list of channel manifest version changes or empty list if no changes found
+     */
+    public InstallationUpdates(List<ArtifactChange> artifactUpdates, List<ManifestVersionChange> manifestUpdates) {
+        Objects.requireNonNull(artifactUpdates);
+        Objects.requireNonNull(manifestUpdates);
+
+        this.artifactUpdates = Collections.unmodifiableList(artifactUpdates);
+        this.manifestUpdates = Collections.unmodifiableList(manifestUpdates);
+    }
+
+    /**
+     * @return list of artifact changes or empty list if no changes found
+     */
+    public List<ArtifactChange> artifactUpdates() {
+        return artifactUpdates;
+    }
+
+    /**
+     * @return list of channel manifest version changes or empty list if no changes found
+     */
+    public List<ManifestVersionChange> manifestUpdates() {
+        return manifestUpdates;
+    }
+}

--- a/src/main/java/org/wildfly/installationmanager/ManifestVersionChange.java
+++ b/src/main/java/org/wildfly/installationmanager/ManifestVersionChange.java
@@ -1,0 +1,65 @@
+package org.wildfly.installationmanager;
+
+/**
+ * Represents possible Channel Manifest version change that would happen if user proceeds with an update operation.
+ */
+public class ManifestVersionChange {
+
+    private final String channelName;
+    private final String location;
+    private final String currentVersion;
+    private final String newVersion;
+    private final boolean isDowngrade;
+
+    /**
+     * Constructor
+     *
+     * @param channelName name of the channel associated with a manifest which is to be updated
+     * @param location manifest location (Maven GA(V) or URL)
+     * @param currentVersion current manifest version
+     * @param newVersion the new manifest version to be updated to
+     * @param isDowngrade is this version change considered a downgrade?
+     */
+    public ManifestVersionChange(String channelName, String location, String currentVersion, String newVersion, boolean isDowngrade) {
+        this.channelName = channelName;
+        this.location = location;
+        this.currentVersion = currentVersion;
+        this.newVersion = newVersion;
+        this.isDowngrade = isDowngrade;
+    }
+
+    /**
+     * @return name of the channel associated with a manifest which is to be updated
+     */
+    public String getChannelName() {
+        return channelName;
+    }
+
+    /**
+     * @return manifest location (Maven GA(V) or URL)
+     */
+    public String getLocation() {
+        return location;
+    }
+
+    /**
+     * @return current manifest version
+     */
+    public String getCurrentVersion() {
+        return currentVersion;
+    }
+
+    /**
+     * @return the new manifest version to be updated to
+     */
+    public String getNewVersion() {
+        return newVersion;
+    }
+
+    /**
+     * @return is this version change considered a downgrade?
+     */
+    public boolean isDowngrade() {
+        return isDowngrade;
+    }
+}

--- a/src/main/java/org/wildfly/installationmanager/ManifestVersionChange.java
+++ b/src/main/java/org/wildfly/installationmanager/ManifestVersionChange.java
@@ -7,8 +7,8 @@ public class ManifestVersionChange {
 
     private final String channelName;
     private final String location;
-    private final String currentVersion;
-    private final String newVersion;
+    private final ManifestVersionPair currentVersion;
+    private final ManifestVersionPair newVersion;
     private final boolean isDowngrade;
 
     /**
@@ -20,7 +20,7 @@ public class ManifestVersionChange {
      * @param newVersion the new manifest version to be updated to
      * @param isDowngrade is this version change considered a downgrade?
      */
-    public ManifestVersionChange(String channelName, String location, String currentVersion, String newVersion, boolean isDowngrade) {
+    public ManifestVersionChange(String channelName, String location, ManifestVersionPair currentVersion, ManifestVersionPair newVersion, boolean isDowngrade) {
         this.channelName = channelName;
         this.location = location;
         this.currentVersion = currentVersion;
@@ -45,14 +45,14 @@ public class ManifestVersionChange {
     /**
      * @return current manifest version
      */
-    public String getCurrentVersion() {
+    public ManifestVersionPair getCurrentVersion() {
         return currentVersion;
     }
 
     /**
      * @return the new manifest version to be updated to
      */
-    public String getNewVersion() {
+    public ManifestVersionPair getNewVersion() {
         return newVersion;
     }
 
@@ -62,4 +62,5 @@ public class ManifestVersionChange {
     public boolean isDowngrade() {
         return isDowngrade;
     }
+
 }

--- a/src/main/java/org/wildfly/installationmanager/ManifestVersionPair.java
+++ b/src/main/java/org/wildfly/installationmanager/ManifestVersionPair.java
@@ -1,0 +1,61 @@
+package org.wildfly.installationmanager;
+
+import java.util.Objects;
+
+/**
+ * Wraps a pair of manifest physical/logical version strings.
+ */
+public class ManifestVersionPair {
+    private final String physicalVersion;
+    private final String logicalVersion;
+
+    /**
+     * Pair of physical / logical version strings.
+     *
+     * @param physicalVersion version string, either a maven artifact version for Maven-based channels,
+     *                        or a URL for URL-based channels
+     * @param logicalVersion  descriptive version string intended for human understanding, optional
+     */
+    public ManifestVersionPair(String physicalVersion, String logicalVersion) {
+        this.physicalVersion = physicalVersion;
+        this.logicalVersion = logicalVersion;
+    }
+
+    /**
+     * @return descriptive version string intended for human understanding, optional
+     */
+    public String getLogicalVersion() {
+        return logicalVersion;
+    }
+
+    /**
+     * @return physicalVersion version string, either a maven artifact version for Maven-based channels,
+     * or a URL for URL-based channels
+     */
+    public String getPhysicalVersion() {
+        return physicalVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "ManifestVersionPair{" +
+                "physicalVersion='" + physicalVersion + '\'' +
+                ", logicalVersion='" + logicalVersion + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ManifestVersionPair that = (ManifestVersionPair) o;
+        return Objects.equals(physicalVersion, that.physicalVersion) && Objects.equals(logicalVersion, that.logicalVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hashCode(physicalVersion);
+        result = 31 * result + Objects.hashCode(logicalVersion);
+        return result;
+    }
+}

--- a/src/main/java/org/wildfly/installationmanager/spi/InstallationManager.java
+++ b/src/main/java/org/wildfly/installationmanager/spi/InstallationManager.java
@@ -18,12 +18,13 @@
 
 package org.wildfly.installationmanager.spi;
 
+import org.wildfly.installationmanager.ArtifactChange;
 import org.wildfly.installationmanager.CandidateType;
 import org.wildfly.installationmanager.FileConflict;
 import org.wildfly.installationmanager.InstallationChanges;
 import org.wildfly.installationmanager.Channel;
 import org.wildfly.installationmanager.HistoryResult;
-import org.wildfly.installationmanager.ArtifactChange;
+import org.wildfly.installationmanager.InstallationUpdates;
 import org.wildfly.installationmanager.ManifestVersion;
 import org.wildfly.installationmanager.OperationNotAvailableException;
 import org.wildfly.installationmanager.Repository;
@@ -65,6 +66,10 @@ public interface InstallationManager {
     /**
      * Prepares an updated version of the server installation in {@code candidatePath}.
      * If no updates are found, this operation does nothing.
+     * <p>
+     * This method throws RuntimeException is the operation would result in subscribed channel manifest being
+     * downgraded. Use {@link #prepareUpdate(Path candidatePath, List repositories, boolean allowManifestDowngrades)}
+     * if you want to allow manifest downgrades.
      *
      * @param candidatePath {@code Path} were the updated version of the server should be located.
      * @param repositories  List of repositories to be used to prepare this update.If it is null or an empty list,
@@ -76,7 +81,39 @@ public interface InstallationManager {
     boolean prepareUpdate(Path candidatePath, List<Repository> repositories) throws Exception;
 
     /**
+     * Prepares an updated version of the server installation in {@code candidatePath}.
+     * If no updates are found, this operation does nothing.
+     *
+     * @param candidatePath {@code Path} were the updated version of the server should be located.
+     * @param repositories  List of repositories to be used to prepare this update.If it is null or an empty list,
+     *                      the default repositories will be used instead.
+     * @param allowManifestDowngrades are manifest downgrades allowed? An attempt do downgrade will result in RuntimeException being thrown if this is false.
+     * @return true if the update candidate was generated, false if candidate was no generated due to not finding any pending updates
+     * @throws IllegalArgumentException if the Path is not writable.
+     * @throws Exception                In case of an error.
+     */
+    boolean prepareUpdate(Path candidatePath, List<Repository> repositories, boolean allowManifestDowngrades) throws Exception;
+
+    /**
+     * Prepares an updated version of the server installation in {@code candidatePath}.
+     * If no updates are found, this operation does nothing.
+     *
+     * @param candidatePath {@code Path} were the updated version of the server should be located.
+     * @param repositories  List of repositories to be used to prepare this update.If it is null or an empty list,
+     *                      the default repositories will be used instead.
+     * @param manifestVersions Manifest versions to update to. All subscribed channels have to be specified.
+     * @param allowManifestDowngrades are manifest downgrades allowed? An attempt do downgrade will result in RuntimeException being thrown if this is false.
+     * @return true if the update candidate was generated, false if candidate was no generated due to not finding any pending updates
+     * @throws IllegalArgumentException if the Path is not writable.
+     * @throws Exception                In case of an error.
+     */
+    boolean prepareUpdate(Path candidatePath, List<Repository> repositories, List<ManifestVersion> manifestVersions, boolean allowManifestDowngrades) throws Exception;
+
+    /**
      * Lists updates available for the server installation.
+     *
+     * @deprecated Deprecated in favour of {@link #findInstallationUpdates(List repositories)}, which returns info
+     *  about upgraded manifests, as well as upgraded artifacts.
      *
      * @param repositories List of repositories to be used to find the available updates. If it is null or an empty list,
      *                     the default repositories will be used instead.
@@ -84,6 +121,27 @@ public interface InstallationManager {
      * @throws Exception In case of an error.
      */
     List<ArtifactChange> findUpdates(List<Repository> repositories) throws Exception;
+
+    /**
+     * Lists updates available for the server installation.
+     *
+     * @param repositories List of repositories to be used to find the available updates. If it is null or an empty list,
+     *                     the default repositories will be used instead.
+     * @return {@link InstallationUpdates} collections of artifact and channels that are to be updated.
+     * @throws Exception In case of an error.
+     */
+    InstallationUpdates findInstallationUpdates(List<Repository> repositories) throws Exception;
+
+    /**
+     * Lists updates available for the server installation.
+     *
+     * @param repositories List of repositories to be used to find the available updates. If it is null or an empty list,
+     *                     the default repositories will be used instead.
+     * @param manifestVersions Manifest versions to update to. All subscribed channels have to be specified.
+     * @return {@link InstallationUpdates} collections of artifact and channels that are to be updated.
+     * @throws Exception In case of an error.
+     */
+    InstallationUpdates findInstallationUpdates(List<Repository> repositories, List<ManifestVersion> manifestVersions) throws Exception;
 
     /**
      * Lists channels the server installation is subscribed to.

--- a/src/main/java/org/wildfly/installationmanager/spi/InstallationManager.java
+++ b/src/main/java/org/wildfly/installationmanager/spi/InstallationManager.java
@@ -19,6 +19,7 @@
 package org.wildfly.installationmanager.spi;
 
 import org.wildfly.installationmanager.ArtifactChange;
+import org.wildfly.installationmanager.AvailableManifestVersions;
 import org.wildfly.installationmanager.CandidateType;
 import org.wildfly.installationmanager.FileConflict;
 import org.wildfly.installationmanager.InstallationChanges;
@@ -127,7 +128,7 @@ public interface InstallationManager {
      *
      * @param repositories List of repositories to be used to find the available updates. If it is null or an empty list,
      *                     the default repositories will be used instead.
-     * @return {@link InstallationUpdates} collections of artifact and channels that are to be updated.
+     * @return {@link InstallationUpdates} collections of artifact and Wildfly Channel manifests that can be updated.
      * @throws Exception In case of an error.
      */
     InstallationUpdates findInstallationUpdates(List<Repository> repositories) throws Exception;
@@ -138,10 +139,21 @@ public interface InstallationManager {
      * @param repositories List of repositories to be used to find the available updates. If it is null or an empty list,
      *                     the default repositories will be used instead.
      * @param manifestVersions Manifest versions to update to. All subscribed channels have to be specified.
-     * @return {@link InstallationUpdates} collections of artifact and channels that are to be updated.
+     * @return {@link InstallationUpdates} collections of artifact and Wildfly Channel manifests that can be updated.
      * @throws Exception In case of an error.
      */
     InstallationUpdates findInstallationUpdates(List<Repository> repositories, List<ManifestVersion> manifestVersions) throws Exception;
+
+    /**
+     * Lists possible upgrades for subscribed manifests. The results may not include manifests for which no upgrades
+     * are available. Only Maven-based manifests are returned, no upgrades are be listed for URL-based manifests.
+     *
+     * @param repositories List of repositories to be used to find the available updates. If it is null or an empty list,
+     *                     the default repositories will be used instead.
+     * @param includeDowngrades If true, manifest versions lower than currently used manifest version will be listed as well.
+     * @return list of AvailableManifestVersions objects containing manifest info and list of available manifest versions.
+     */
+    List<AvailableManifestVersions> findAvailableManifestVersions(List<Repository> repositories, boolean includeDowngrades) throws Exception;
 
     /**
      * Lists channels the server installation is subscribed to.


### PR DESCRIPTION
This is port of https://github.com/wildfly/wildfly-installation-manager-api/pull/45 to 1.2.x branch.